### PR TITLE
Modify TLV to support long records

### DIFF
--- a/nfc_gen_url.py
+++ b/nfc_gen_url.py
@@ -89,7 +89,13 @@ def gen_nfc_sub(tag_data):
 
     data_list.extend(data_static)
     data_list.append(3)         # Message Flags
-    data_list.append(m_len)         # Type Length
+    if m_len < 255:
+        data_list.append(m_len)         # Type Length
+    else:
+        data_list.append(0xFF)
+        lenStr = hex(m_len)[2:].rjust(4, "0")
+        data_list.append(int(lenStr[0:2], 16))
+        data_list.append(int(lenStr[2:4], 16))
     data_list.extend(list(buf))
 
     data_list.append(0xFE)      # end of Data


### PR DESCRIPTION
Hello! I am writing my own CLI for adding other NDEF record types to NFC Tags, and ran into this problem myself. I love your library, and thought I would send in a quick fix!

The TLV format in the MiFare specs is different if the NDEF Message is longer than 255 bytes. If the length is not specified in this format, longer URLs will not open in most readers.

- TLVs where the data field has a length from 0 to 254 bytes:

|   TAG    | LENGTH n | DATA      |
|:--------:|:--------:|:---------:|
| (1 byte) | (1 byte) | (n bytes) |

- TLVs where the data field has a length from 255 to 65534 bytes:

|   TAG    | 0xFF     | LENGTH n  |   DATA    |
|:--------:| -------- |:---------:|:---------:|
| (1 byte) | (1 byte) | (2 bytes) | (n bytes) |


Here is a long test URL if you need it!
[Long URL on my site](https://mcclurgdev.io/projects/say?title=Dear%20Reviewer%2C&body=Here%20is%20a%20dumb%20test%20page%20you%20can%20use%20to%20make%20sure%20longer%20URLs%20will%20open!%0A%0AThis%20message%20is%20passed%20by%20URL%20query%20parameter.%20Make%20it%20say%20whatever%20your%20want!&footer=Made%20with%20%E2%9D%A4%EF%B8%8F%20by%20Chris%20McClurg%20)